### PR TITLE
Remove Leaderboard Images

### DIFF
--- a/skills/leaderboard.js
+++ b/skills/leaderboard.js
@@ -266,7 +266,6 @@ module.exports = function helper(controller, context) {
       service, bot, message, content, dateRange: 30,
     })
       .then(getLeaderboard)
-      .then(getUserIcons)
       .then(addContentHeading)
     // These are alternative layouts for the user list. I am leaving them here
     // intentionally in case we decide to use them later
@@ -294,7 +293,6 @@ module.exports = function helper(controller, context) {
       service, bot, message, content, dateRange: message.actions[0].value,
     })
       .then(getLeaderboard)
-      .then(getUserIcons)
       .then(addContentHeading)
     // These are alternative layouts for the user list. I am leaving them here
     // intentionally in case we decide to use them later

--- a/skills/leaderboard.js
+++ b/skills/leaderboard.js
@@ -129,7 +129,6 @@ const addContentUsersContext = (state) => {
   const userToScoreBlock = (user, index) => ({
     type: 'context',
     elements: [
-      { type: 'image', image_url: state.icons[user.userID], alt_text: `<@${user.userID}>` },
       { type: 'mrkdwn', text: `<@${user.userID}> *${rank[index]} - Score:* ${Math.round(user.score * 100) / 100}\n` },
     ],
   });


### PR DESCRIPTION
From some local testing it appears that rendering the images in the leaderboard is causing significant slowdowns during the 'leaderboard' command. This PR removes the images entirely, although downscaling them might be another option.